### PR TITLE
Support for HTML5 time element; option for lowercase dates

### DIFF
--- a/src-test/humaneDatesPluginTest.js
+++ b/src-test/humaneDatesPluginTest.js
@@ -48,3 +48,14 @@ HumaneDatesPluginTest.prototype.testHtml5 = function()
 
     assertEquals('2 Minutes', jQuery('time').html());
 };
+
+HumaneDatesPluginTest.prototype.testLowercase = function()
+{
+    var d = new Date;
+    d.setTime(d.getTime() + 120*1000);
+
+    jQuery(document.body).append('<time datetime="' + this.getUTCDate(d) + '">test</time>');
+    jQuery('time').humaneDates({'lowercase': true});
+
+    assertEquals('2 minutes', jQuery('time').html());
+};

--- a/src-test/humaneDatesPluginTest.js
+++ b/src-test/humaneDatesPluginTest.js
@@ -38,3 +38,13 @@ HumaneDatesPluginTest.prototype.testMinutes = function()
     assertEquals('2 Minutes', jQuery('span').html());
 };
 
+HumaneDatesPluginTest.prototype.testHtml5 = function()
+{
+    var d = new Date;
+    d.setTime(d.getTime() + 120*1000);
+
+    jQuery(document.body).append('<time datetime="' + this.getUTCDate(d) + '">test</time>');
+    jQuery('time').humaneDates();
+
+    assertEquals('2 Minutes', jQuery('time').html());
+};

--- a/src/humane.js
+++ b/src/humane.js
@@ -108,7 +108,7 @@ if(typeof jQuery != 'undefined') {
         return this.each(function()
         {
             var $t = jQuery(this),
-                date = humaneDate($t.attr('title'));
+                date = humaneDate($t.attr('datetime')) || humaneDate($t.attr('title'));
 
             if(date && $t.html() != date) {
                 // don't modify the dom if we don't have to

--- a/src/humane.js
+++ b/src/humane.js
@@ -103,12 +103,20 @@ function humaneDate(date, compareTo){
 };
 
 if(typeof jQuery != 'undefined') {
-    jQuery.fn.humaneDates = function()
+    jQuery.fn.humaneDates = function(options)
     {
+        var settings = $.extend({
+            'lowercase': false
+        }, options);
+
         return this.each(function()
         {
             var $t = jQuery(this),
                 date = humaneDate($t.attr('datetime')) || humaneDate($t.attr('title'));
+
+            if(date && settings['lowercase']) {
+                date = date.toLowerCase();
+            }
 
             if(date && $t.html() != date) {
                 // don't modify the dom if we don't have to


### PR DESCRIPTION
Support HTML5's time element (a preferred way to markup dates, which includes W3CTDF dates in the "datetime" attribute).

Also, add option to jQuery plugin to lowercase generated dates.

Unit tests included for both.

Sorry for adding 2 features in the same branch!
