### PR TITLE
[Firefox 11]: fix ISO string w/ fractional secs

### DIFF
--- a/humane.js
+++ b/humane.js
@@ -45,7 +45,9 @@ function humaneDate(date, compareTo){
         ],
         isString = typeof date == 'string',
         date = isString ?
-                    new Date(('' + date).replace(/-/g,"/").replace(/[TZ]/g," ")) :
+                    new Date(('' + date)
+                         .replace(/-/g,"/")
+                         .replace(/T|(?:\.\d+)?Z/g," ")) :
                     date,
         compareTo = compareTo || new Date,
         seconds = (compareTo - date +

--- a/test/humaneDatesTest.js
+++ b/test/humaneDatesTest.js
@@ -19,6 +19,14 @@ HumaneDatesTest.prototype.testNowAgoMax = function()
     assertEquals('Just Now', humaneDate(d));
 };
 
+HumaneDatesTest.prototype.testISO8601WithFractionalSeconds = function()
+{
+    var d = new Date;
+    d.setTime(d.getTime() - 59.1*1000);
+    d = d.toISOString();
+    assertEquals('Just Now', humaneDate(d));
+};
+
 HumaneDatesTest.prototype.testMinute = function()
 {
     var d = new Date;


### PR DESCRIPTION
Firefox 11 (at least on Linux) doesn't seem to like fractional secs
in the ISO string being passed to the Date constructor, so just
strip those out along with the Z at the end of the string.
